### PR TITLE
Added option to allow static_domains to pass directly or block it.

### DIFF
--- a/zyte_smartproxy_selenium/webdriver.py
+++ b/zyte_smartproxy_selenium/webdriver.py
@@ -104,7 +104,7 @@ class ZyteModifyRequestsMixin:
         if self.block_ads and self.block_ads_rules.should_block(request.url):
             request.abort()
 
-        if self.static_domains_list > 0:
+        if len(self.static_domains_list) > 0:
 
             for _domain in self.static_domains_list:
 


### PR DESCRIPTION
Added option to allow static_domains such as accounts.google.com etc to load directly or block sending the request entirely.

DEFAULT_STATIC_DOMAINS
DEFAULT_STATIC_DOMAINS_LIST

Expects a list of domains such as ['accounts.google.com', 'google.com'] when matched with request.url it will send it directly or abort the request if DEFAULT_STATIC_DOMAINS_BLOCK is set to TRUE.

Recently had a case where a request to website was loading un-necessary domains, we had to add the domains to a list and host it on github and mentioned that link under DEFAULT_BLOCK_ADS_LISTS so that it can be dropped/blocked from sending request to that domain via SPM.